### PR TITLE
avoid fake User-Agent, /mail/mu/ instead

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -73,7 +73,7 @@ config.gmail = {
     app.storage.write("gmail-label", val);
   },
   get url () {
-    return app.storage.read("gmail-url") || "https://mail.google.com/";
+    return app.storage.read("gmail-url") || "https://mail.google.com/mail/mu/";
   },
   set url (val) {
     app.storage.write("gmail-url", val);

--- a/src/lib/firefox/firefox.js
+++ b/src/lib/firefox/firefox.js
@@ -262,8 +262,8 @@ var httpRequestObserver = {
             }
             if (start(loadContext)) {
               //var value = 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B) AppleWebkit/537.36 (KHTML, like Gecko) Mobile Safari/537.36';
-              var value = 'Mozilla/5.0 (Android 5.1.1; Mobile; rv:43.0) Gecko/43.0 Firefox/43.0';
-              httpChannel.setRequestHeader("User-Agent", value, false);
+              //var value = 'Mozilla/5.0 (Android 5.1.1; Mobile; rv:43.0) Gecko/43.0 Firefox/43.0';
+              //httpChannel.setRequestHeader("User-Agent", value, false);
             }
           }
           catch (e) {}


### PR DESCRIPTION
This is an idea and proposals.
"https://mail.google.com/mail/mu/" works for call mobile interface, instead of fake UA.

I did not modify the code for Chrome and cleanup, I think this is helpful, but I did not get the extension (0.2.2) works in Chrome 52.
I don't understand the purposes of storage the "gmail-url".

The origin:
I met https://support.google.com/mail/answer/43692 many times this month, with whichever time interval. It before everything was normal. Visit the inbox.google.com website is normal when the exception occurs.

I guess this changes will help Google to detect the actual environment, although there is not a rigorous and long-term testing.
